### PR TITLE
Add GolemCore Bot to Agent Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 |-----------|------|
 | SuperAGI | [TransformerOptimus/SuperAGI](https://github.com/TransformerOptimus/SuperAGI) |
 
+| GolemCore Bot | [alexk-dev/golemcore-bot](https://github.com/alexk-dev/golemcore-bot) |
 ### 2.1 Multi Agent Framework
 | Project | Link |
 |---------|------|


### PR DESCRIPTION
Adding GolemCore Bot to the list of agent frameworks.