### PR TITLE
Add Dakera to Agent Framework section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## 2. Agent Framework
 | Framework | Link |
 |-----------|------|
-| Dakera | [dakera-ai/dakera-deploy-deploy](https://github.com/dakera-ai/dakera-deploy-deploy) |
+| Dakera | [dakera-ai/dakera-deploy](https://github.com/dakera-ai/dakera-deploy) |
 | SuperAGI | [TransformerOptimus/SuperAGI](https://github.com/TransformerOptimus/SuperAGI) |
 | GolemCore Bot | [alexk-dev/golemcore-bot](https://github.com/alexk-dev/golemcore-bot) |
 ### 2.1 Multi Agent Framework

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## 2. Agent Framework
 | Framework | Link |
 |-----------|------|
-| Dakera | [Dakera-AI/dakera](https://github.com/Dakera-AI/dakera) |
+| Dakera | [dakera-ai/dakera-deploy-deploy](https://github.com/dakera-ai/dakera-deploy-deploy) |
 | SuperAGI | [TransformerOptimus/SuperAGI](https://github.com/TransformerOptimus/SuperAGI) |
 | GolemCore Bot | [alexk-dev/golemcore-bot](https://github.com/alexk-dev/golemcore-bot) |
 ### 2.1 Multi Agent Framework

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ## 2. Agent Framework
 | Framework | Link |
 |-----------|------|
+| Dakera | [Dakera-AI/dakera](https://github.com/Dakera-AI/dakera) |
 | SuperAGI | [TransformerOptimus/SuperAGI](https://github.com/TransformerOptimus/SuperAGI) |
 | GolemCore Bot | [alexk-dev/golemcore-bot](https://github.com/alexk-dev/golemcore-bot) |
 ### 2.1 Multi Agent Framework


### PR DESCRIPTION
Adds [Dakera](https://github.com/Dakera-AI/dakera) to the Agent Framework section.

Dakera is a production-ready persistent memory layer for AI agents — the infrastructure layer that gives agents durable memory across sessions. It supports multi-tenant namespacing, hybrid BM25 + vector retrieval, and temporal reasoning.

Integrates with major frameworks: LangChain, LlamaIndex, CrewAI, AutoGen.

- Docs: https://docs.dakera.ai