### PR TITLE
Add rust-norion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | Awesome AI Agents | [e2b-dev/awesome-ai-agents](https://github.com/e2b-dev/awesome-ai-agents) |
 | Open Interpreter | [OpenInterpreter/open-interpreter](https://github.com/OpenInterpreter/open-interpreter) |
 | Adala | [HumanSignal/Adala](https://github.com/HumanSignal/Adala) |
+| rust-norion | [yanghao1143/rust-norion](https://github.com/yanghao1143/rust-norion) |
 
 ## 2. Agent Framework
 | Framework | Link |


### PR DESCRIPTION
Adds rust-norion to the open-source projects table.

Why this fits:
- rust-norion is an open-source Rust prototype around AI runtime-control boundaries;
- relevant surfaces include routing, memory gates, evidence checks, rollback, and audit traces;
- the change follows the existing two-column table format.

Scope note: rust-norion is an early prototype, not a production inference engine.