### PR TITLE
Add ClawBench web-agent benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 | Project | Link |
 |---------|------|
 | BrowserGym | [ServiceNow/BrowserGym](https://github.com/ServiceNow/BrowserGym) |
+| ClawBench | [TIGER-AI-Lab/ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) |
 | WebArena | [webarena.dev](https://webarena.dev/) |
 | VisualWebArena | [https://github.com/web-arena-x/visualwebarena](https://github.com/web-arena-x/visualwebarena) |
 


### PR DESCRIPTION
## Summary

- add ClawBench to Research Oriented Web Browsing Framework
- match the existing two-column project/link format
- link the canonical repository

## Validation

- `git diff --check`
- verified the repository URL returns HTTP 200

I am a ClawBench maintainer and am submitting this entry in that capacity. This contribution was prepared with AI assistance.

Project: https://claw-bench.com/
Paper: https://arxiv.org/abs/2604.08523
Repository: https://github.com/TIGER-AI-Lab/ClawBench
