### PR TITLE
Add Agon to Multi Agent Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 ### 2.1 Multi Agent Framework
 | Project | Link |
 |---------|------|
+| Agon | [AutoResearch-Factory/Agon](https://github.com/AutoResearch-Factory/Agon) |
 | Agent Protocol | [AI-Engineer-Foundation/agent-protocol](https://github.com/AI-Engineer-Foundation/agent-protocol) |
 | AutoGen | [microsoft/autogen](https://github.com/microsoft/autogen) |
 | MetaGPT | [geekan/MetaGPT](https://github.com/geekan/MetaGPT) |


### PR DESCRIPTION
Add Agon to Multi Agent Framework.

Agon is an autonomous omnidisciplinary research orchestrator built as a Claude Code plugin. Scientist/coder/auditor loops across 10+ disciplines, governed by Prompt Economy.