### PR TITLE
docs: add SandBase CLI agent framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 |-----------|------|
 | SuperAGI | [TransformerOptimus/SuperAGI](https://github.com/TransformerOptimus/SuperAGI) |
 | GolemCore Bot | [alexk-dev/golemcore-bot](https://github.com/alexk-dev/golemcore-bot) |
+| SandBase CLI | [sandbaseai/cli](https://github.com/sandbaseai/cli) |
 ### 2.1 Multi Agent Framework
 | Project | Link |
 |---------|------|


### PR DESCRIPTION
## Summary
- add SandBase CLI to the Agent Framework table
- link the open-source CLI and MCP bridge for 2,000+ AI models

Project: https://github.com/sandbaseai/cli