### PR TITLE
Add Orkas to open-source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | Awesome AI Agents | [e2b-dev/awesome-ai-agents](https://github.com/e2b-dev/awesome-ai-agents) |
 | Open Interpreter | [OpenInterpreter/open-interpreter](https://github.com/OpenInterpreter/open-interpreter) |
 | Adala | [HumanSignal/Adala](https://github.com/HumanSignal/Adala) |
+| Orkas | [Orkas-AI/Orkas](https://github.com/Orkas-AI/Orkas) |
 
 ## 2. Agent Framework
 | Framework | Link |


### PR DESCRIPTION
Adds Orkas to 1.2 Open Source Projects using the existing entry format.

Orkas is an open-source, local-first desktop AI workforce coordinated by a Commander through one chat.

Validation: checked the project source, target category, existing entries and prior suggestions; git diff --check passes.

Affiliation: submitted on behalf of the Orkas project.
